### PR TITLE
conda-tree v1.1.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "conda-tree" %}
-{% set version = "1.0.5" %}
+{% set version = "1.1.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,23 +7,22 @@ package:
 
 source:
   url: https://github.com/rvalieris/{{ name }}/archive/v{{ version }}.tar.gz
-  sha256: 0fef56e342eb6fd5a131846342bfdad357f2951d616aa90752ac7fdf6523bf39
+  sha256: e56ffb0389a7d74a9b89f9ceda3359063d19ed0795d88555f17c41c9fcee645e
 
 build:
   number: 0
-  noarch: python
-  script:
-    - {{ PYTHON }} -m pip install . --no-deps -vv
+  skip: true #[py<39]
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   entry_points:
     - conda-tree = conda_tree:main
 
 requirements:
   host:
-    - python >=3.6
+    - python
     - pip
     - setuptools
   run:
-    - python >=3.6
+    - python
     - networkx
     - conda
     - colorama

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,6 +21,7 @@ requirements:
     - python
     - pip
     - setuptools
+    - wheel
   run:
     - python
     - networkx
@@ -37,6 +38,8 @@ about:
   license_family: MIT
   license_file: LICENSE
   summary: conda dependency tree helper
+  description: |
+    conda dependency tree helper
   dev_url: https://github.com/rvalieris/conda-tree
   doc_url: https://github.com/rvalieris/conda-tree
 


### PR DESCRIPTION
## ☆ conda-tree 1.1.1 ☆
[Jira Ticket](https://anaconda.atlassian.net/browse/PKG-7698) 
[Upstream](https://github.com/rvalieris/conda-tree)

### Changes
* Added Python 3.9+ requirement with skip directive for versions lesser
* Updated to version 1.1.1 and sha update